### PR TITLE
Ensure mutual exclusion when handling (accessing/modifying) Telemetry…

### DIFF
--- a/JAPI/Handlers/TelemetryHandler.cs
+++ b/JAPI/Handlers/TelemetryHandler.cs
@@ -9,7 +9,7 @@ public class TelemetryHandler
     /* Class members */
     private static TelemetryHandler? _instance;
     private readonly Telemetry telemetry = new();
-    private readonly Mutex _mutex = new Mutex(false);
+    public static readonly Mutex _mutex = new Mutex(false);
     private static readonly object _instanceLocker = new();
 
     /* Utility variables for simulation */
@@ -122,6 +122,7 @@ public class TelemetryHandler
 
                     /* Critical section (update telemetry in-memory and to the database (json file) */
                     _mutex.WaitOne();
+                    //Thread.Sleep(2500); // testing purposes (not required for main functionality)
                     telemetry.fuel = newFuel;
                     telemetry.temp = newTemperature;
                     telemetry.status.voltage = newVoltage;
@@ -130,7 +131,7 @@ public class TelemetryHandler
 
                     stopwatch.Restart(); // restart the timestep
 
-                    Console.WriteLine($"{telemetry.fuel} ---> {telemetry.temp} ---> {telemetry.status.voltage}");
+                    Console.WriteLine($"{nameof(telemetry.fuel)}: {telemetry.fuel} ---> {nameof(telemetry.temp)}: {telemetry.temp} ---> {nameof(telemetry.status.voltage)}: {telemetry.status.voltage}");
                 }
                 else
                 {

--- a/JAPI/Program.cs
+++ b/JAPI/Program.cs
@@ -37,7 +37,7 @@ Startup.SendHandler.SetUriValues(serviceDictionary);
 TelemetryHandler telemetryHandler = TelemetryHandler.Instance();
 CancellationTokenSource cancellationTokenSource = new();
 
-double executeSimulation = 30000.0; // execute the simulation every <value> milliseconds
+double executeSimulation = 500.0; // execute the simulation every <value> milliseconds
 
 /* Start async simulation worker */
 Task simulationTask = Task.Run(() =>

--- a/JAPI/TelemetryData.json
+++ b/JAPI/TelemetryData.json
@@ -1,1 +1,1 @@
-{"coordinate":{"x":0,"y":0,"z":0},"rotation":{"p":0,"y":0,"r":0},"fuel":94,"temp":12.200002,"status":{"payloadPower":false,"dataWaiting":false,"chargeStatus":false,"voltage":13.5}}
+{"coordinate":{"x":0,"y":0,"z":0},"rotation":{"p":0,"y":0,"r":0},"fuel":44,"temp":11,"status":{"payloadPower":false,"dataWaiting":false,"chargeStatus":false,"voltage":13.5}}


### PR DESCRIPTION
These changes are to properly implement mutual exclusion regarding the access and modification of `Telemetry Data`. All *threads* share the same Mutex used to control these operations.

Example from FlyingThroughSpace method:
```c#
  /* Critical section (update telemetry in-memory and to the database (json file) */
  _mutex.WaitOne(); // acquire lock
  //Thread.Sleep(2500); // testing purposes (not required for main functionality)
  telemetry.fuel = newFuel;
  telemetry.temp = newTemperature;
  telemetry.status.voltage = newVoltage;
  fh.WriteTelemetryData(fileName, telemetry);
  _mutex.ReleaseMutex(); // release lock
```