### PR TITLE
Sanitize Telemetry Async Handler and Adjust downloadImage response code

### DIFF
--- a/JAPI.Tests/JAPITests.cs
+++ b/JAPI.Tests/JAPITests.cs
@@ -44,7 +44,7 @@ public class JAPITests
     }
 
     [TestMethod]
-    public async Task JAPI002_downloadImage_NoContent_Returns204()
+    public async Task JAPI002_downloadImage_NoContent_Returns200()
     {
         if (_testClient is not null)
         {
@@ -65,7 +65,7 @@ public class JAPITests
             var response = await _testClient.PostAsync("/downloadImage", content).ConfigureAwait(true);
 
             // Arrange
-            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode, "Error code received is not expected 204");
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Error code received is not expected 204");
         }
     }
 
@@ -625,18 +625,18 @@ public class HttpRequestTests
     }
 
     [TestMethod]
-    public async Task HttpRequestHandler002_SendRawData_ReturnsCode()
+    public async Task HttpRequestHandler002_SendPackagedData_ReturnsCode()
     {
         //Arrange and Act
-        TestRawData data = new TestRawData();
-        data.raw = "raw";
-        data.sequence = 69;
-        string sendData = System.Text.Json.JsonSerializer.Serialize(data);
-
-        var requestContent = new StringContent(sendData, Encoding.UTF8, "application/json");
+        Telemetry telemetryData = new();
+        telemetryData.coordinate = new Coordinate(0.6f, 0.7f, 0.1f);
+        telemetryData.rotation = new Rotation(0.10f, 0.69f, 0.5f);
+        telemetryData.fuel = 50f;
+        telemetryData.temp = 21.5f;
+        telemetryData.status = new Status(true, true, true, 0.000001f);
 
         int ID = 3;
-        HttpResponseMessage response = await _httpRequestHandler.SendPackagedData(requestContent, ID).ConfigureAwait(true);
+        HttpResponseMessage response = await _httpRequestHandler.SendPackagedData(telemetryData, ID).ConfigureAwait(true);
 
         //Assert
 #if DEBUG

--- a/JAPI/Handlers/HttpRequestHandler.cs
+++ b/JAPI/Handlers/HttpRequestHandler.cs
@@ -130,22 +130,24 @@ public class HttpRequestHandler : Controller
         return response;
     }
 
-    public async Task<HttpResponseMessage> SendPackagedData(StringContent content, int ID)
+    public async Task<HttpResponseMessage> SendPackagedData(Telemetry telemetry, int ID)
     {
         // Uri
         StringContent requestContent;
-        string apiUrl = UriValues[SpaceUpDown] + ":8080/C&DH_Received";
+        string apiUrl = start + UriValues[SpaceUpDown] + portNumber + "/C&DH_Receive";
         Console.WriteLine(apiUrl);
         try
         {
             var requestData = new Packet();
             requestData.verb = "PUT";
             requestData.uri = UriValues[ID] + ":8080/telemetry";
-            requestData.content = content.ReadAsStringAsync().Result;
+            requestData.content = telemetry;
             var sendData = JsonSerializer.Serialize(requestData);
             requestContent = new StringContent(sendData, Encoding.UTF8, "application/json");
             string requestConverted = requestContent.ReadAsStringAsync().Result;
-
+#if DEBUG
+            Console.WriteLine($"requestConverted in DEBUG\n{requestConverted}");
+#endif
         }
         catch (Exception ex)
         {
@@ -227,5 +229,5 @@ public class Packet
 {
     public string verb { get; set; }
     public string uri { get; set; }
-    public String content { get; set; }
+    public object content { get; set; }
 }

--- a/JAPI/Program.cs
+++ b/JAPI/Program.cs
@@ -37,7 +37,7 @@ Startup.SendHandler.SetUriValues(serviceDictionary);
 TelemetryHandler telemetryHandler = TelemetryHandler.Instance();
 CancellationTokenSource cancellationTokenSource = new();
 
-double executeSimulation = 500.0; // execute the simulation every <value> milliseconds
+double executeSimulation = 30000.0; // execute the simulation every <value> milliseconds
 
 /* Start async simulation worker */
 Task simulationTask = Task.Run(() =>

--- a/JAPI/Startup.cs
+++ b/JAPI/Startup.cs
@@ -62,7 +62,7 @@ public class Startup
                 var sendData = JsonSerializer.Serialize(getTelemetryData);
                 var requestContent = new StringContent(sendData, Encoding.UTF8, "application/json");
 
-                SendHandler.SendPackagedData(requestContent, source);
+                SendHandler.SendPackagedData(getTelemetryData, source);
             })
             .WithName("telemetry")
             .WithOpenApi();
@@ -129,7 +129,7 @@ public class Startup
             endpoints.MapPost("/downloadImage", async (HttpContext ctx) =>
             {
                 /* Configure the response */
-                ctx.Response.StatusCode = StatusCodes.Status204NoContent;
+                ctx.Response.StatusCode = StatusCodes.Status200OK; // payload ops requires 200OK instead of 204NoContent
 
                 /* Send Response*/
                 ctx.Response.CompleteAsync();

--- a/JAPI/TelemetryData.json
+++ b/JAPI/TelemetryData.json
@@ -1,1 +1,1 @@
-{"coordinate":{"x":0,"y":0,"z":0},"rotation":{"p":0,"y":0,"r":0},"fuel":44,"temp":11,"status":{"payloadPower":false,"dataWaiting":false,"chargeStatus":false,"voltage":13.5}}
+{"coordinate":{"x":0,"y":0,"z":0},"rotation":{"p":0,"y":0,"r":0},"fuel":98,"temp":11.799999,"status":{"payloadPower":false,"dataWaiting":false,"chargeStatus":false,"voltage":12.5}}


### PR DESCRIPTION
Details related to Issue **949** can be found in our Azure Board

Fixes/Enhancements:

- Sanitize GET Telemetry Async Handler
- Adjust /downloadImage response code from 204 No Content to 200 OK to avoid library incompatibilities from Payload Ops
- Modify dependent test cases that failed after changes were made

Small changes :)